### PR TITLE
F3070

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+TRex is a high-performance, DPDK-based network traffic generator by Cisco. It supports three traffic modes:
+- **STF (Stateful)**: Flow-based stateful traffic for testing NAT, DPI, firewalls, IPS/IDS
+- **STL (Stateless)**: Stream-based packet generation for routing/switching, RFC2544 benchmarks
+- **ASTF (Advanced Stateful)**: High-scale TCP/UDP with L7 application emulation (HTTP, HTTPS, etc.)
+
+## Build System
+
+Uses WAF (Python-based build tool). All build commands run from `linux_dpdk/`:
+
+```bash
+cd linux_dpdk
+
+# Configure (required before first build)
+./b configure                    # default configuration
+./b configure --with-bird        # with Bird routing daemon
+./b configure --with-mana        # with Azure Mana driver
+./b configure --no-mlx           # without Mellanox drivers
+./b configure --sanitized        # with address sanitizer (GCC 4.9+)
+./b configure --gcc7             # use GCC 7.4
+./b configure --tap              # add tap driver for Azure
+
+# Build
+./b build
+
+# Package
+./b pkg
+```
+
+Build output goes to `linux_dpdk/build_dpdk/`. Shared libraries go to `scripts/so/<arch>/`.
+
+Requires GCC 4.7.0+ (supports GCC 6, 7, 8). Python 3.3+ required for build scripts.
+
+## Testing
+
+Tests run from `scripts/`:
+
+```bash
+cd scripts
+
+# Run full regression tests
+./run_regression
+
+# Run functional tests only (no hardware needed)
+./run_functional_tests
+
+# Run specific test (via pytest-style args passed to trex_unit_test.py)
+./run_regression --test-name <test>
+```
+
+The test runner is `scripts/automation/regression/trex_unit_test.py`. Test suites are organized under:
+- `scripts/automation/regression/functional_tests/` - Functional tests
+- `scripts/automation/regression/astf_tests/` - ASTF mode tests
+- `scripts/automation/regression/bird_tests/` - Bird integration tests
+- `scripts/automation/regression/emu_tests/` - EMU (client-side protocols) tests
+
+Python 3.4+ required for tests.
+
+## Architecture
+
+### C++ Engine (`src/`)
+
+The high-performance data plane:
+- `main_dpdk.cpp` — DPDK mode entry point (the main production binary)
+- `main.cpp` — Simulator mode entry point (for testing without hardware)
+- `bp_sim.cpp/.h` — Core packet simulation engine
+- `src/stx/` — Traffic mode subsystems: `stf/`, `stl/`, `astf/`, `astf_batch/`
+- `src/44bsd/` — Embedded TCP/IP stack (4.4 BSD-derived)
+- `src/rpc-server/` — JSON-RPC server for control plane communication
+- `src/pal/` — Platform Abstraction Layer for NIC portability
+- `src/drivers/` — NIC-specific driver code
+- `src/tunnels/` — Tunneling protocol support
+- `src/hdrh/` — HDR Histogram for latency tracking
+- `src/gtest/` — Google Test-based C++ unit tests
+- `src/sim/` — Simulation framework
+
+### Python Control Plane (`scripts/`)
+
+- `scripts/automation/trex_control_plane/interactive/trex/` — Interactive TRex client library (main API)
+- `scripts/automation/trex_control_plane/interactive/trex_stl_lib/` — Stateless client library
+- `scripts/dpdk_setup_ports.py` — DPDK port configuration utility
+- `scripts/dpdk_nic_bind.py` — NIC binding tool
+
+### External Libraries (`external_libs/`)
+
+Vendored dependencies including DPDK, yaml-cpp, ZMQ, JSON, valijson, BPF, libibverbs. These are checked into the repo.
+
+## Key Conventions
+
+- Commits require sign-off: `git commit -s` (DCO compliance)
+- Mimic existing code style — no project-wide linter enforced
+- C++ compiler flags include `-Wall -Werror` (GCC) — all warnings are errors
+- The build system generates `version.c`/`version.h` from the `VERSION` file at the repo root

--- a/external_libs/valijson/include/valijson/constraints/basic_constraint.hpp
+++ b/external_libs/valijson/include/valijson/constraints/basic_constraint.hpp
@@ -34,7 +34,7 @@ struct BasicConstraint: Constraint
     BasicConstraint(const BasicConstraint &other)
       : allocator(other.allocator) { }
 
-    virtual ~BasicConstraint<ConstraintType>() { }
+    virtual ~BasicConstraint() { }
 
     virtual bool accept(ConstraintVisitor &visitor) const
     {

--- a/linux/ws_main.py
+++ b/linux/ws_main.py
@@ -531,7 +531,9 @@ cxxflags_base =['-DWIN_UCODE_SIM',
                 '-std=c++0x',
                 '-Wno-sign-compare',
                 '-Wno-strict-aliasing',
-                 '-Wno-address-of-packed-member',]
+                 '-Wno-address-of-packed-member',
+                 '-Wno-maybe-uninitialized',
+                 '-Wno-dangling-pointer',]
 
 cflags_base   =['-DWIN_UCODE_SIM',
                 '-DTREX_SIM',

--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -2098,7 +2098,7 @@ common_flags = ['-DWIN_UCODE_SIM',
 if march == 'x86_64':
     common_flags_new = common_flags + [
                     '-march=native',
-                    '-mssse3', '-msse4.1', '-mpclmul', '-mno-avx2',
+                    '-mssse3', '-msse4.1', '-mpclmul', '-mno-avx', '-mno-avx2',
                     '-DRTE_MACHINE_CPUFLAG_SSE',
                     '-DRTE_MACHINE_CPUFLAG_SSE2',
                     '-DRTE_MACHINE_CPUFLAG_SSE3',

--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -59,7 +59,9 @@ gcc_flags = ['-Wall',
              '-Wno-sign-compare',
              '-Wno-strict-aliasing',
              '-mrtm',
-             '-Wno-address-of-packed-member']
+             '-Wno-address-of-packed-member',
+             '-Wno-maybe-uninitialized',
+             '-Wno-dangling-pointer']
 
 
 

--- a/src/dpdk/drivers/net/intel/iavf/iavf_ethdev.c
+++ b/src/dpdk/drivers/net/intel/iavf/iavf_ethdev.c
@@ -2894,7 +2894,9 @@ iavf_dev_init(struct rte_eth_dev *eth_dev)
 	return 0;
 
 security_init_err:
+#ifdef RTE_LIB_SECURITY
 	iavf_security_ctx_destroy(adapter);
+#endif
 
 flow_init_err:
 	iavf_disable_irq0(hw);

--- a/src/dpdk/drivers/net/intel/iavf/iavf_rxtx_vec_sse.c
+++ b/src/dpdk/drivers/net/intel/iavf/iavf_rxtx_vec_sse.c
@@ -20,7 +20,7 @@ _iavf_rxq_rearm(struct ci_rx_queue *rxq)
 	uint16_t rx_id;
 
 	volatile union ci_rx_desc *rxdp;
-	struct rte_mbuf **rxp = &rxq->sw_ring[rxq->rxrearm_start];
+	struct rte_mbuf **rxp = (struct rte_mbuf **)&rxq->sw_ring[rxq->rxrearm_start];
 	struct rte_mbuf *mb0, *mb1;
 	__m128i hdr_room = _mm_set_epi64x(RTE_PKTMBUF_HEADROOM,
 			RTE_PKTMBUF_HEADROOM);

--- a/src/dpdk/drivers/net/intel/ixgbe/ixgbe_ethdev.h
+++ b/src/dpdk/drivers/net/intel/ixgbe/ixgbe_ethdev.h
@@ -707,6 +707,7 @@ void ixgbe_filterlist_flush(void);
  * Flow director function prototypes
  */
 int ixgbe_fdir_configure(struct rte_eth_dev *dev);
+int trex_ixgbe_fdir_configure(struct rte_eth_dev *dev);
 int ixgbe_fdir_set_input_mask(struct rte_eth_dev *dev);
 int ixgbe_fdir_set_flexbytes_offset(struct rte_eth_dev *dev,
 				    uint16_t offset);

--- a/src/dpdk/drivers/net/ntacc/rte_eth_ntacc.c
+++ b/src/dpdk/drivers/net/ntacc/rte_eth_ntacc.c
@@ -98,6 +98,7 @@ struct supportedDriver_s supportedDriver = {3, 11, 0};
 #define PCI_DEVICE_ID_NT400D11 0x0215
 #define PCI_DEVICE_ID_NT40A11  0x0225
 #define PCI_DEVICE_ID_NT400D13 0x0295
+#define PCI_DEVICE_ID_FS2070X  0x0255
 
 
 
@@ -3292,6 +3293,7 @@ static int rte_pmd_ntacc_dev_probe(struct rte_pci_driver *drv __rte_unused, stru
   case PCI_DEVICE_ID_NT400D11:
   case PCI_DEVICE_ID_NT40A11:
   case PCI_DEVICE_ID_NT400D13:
+  case PCI_DEVICE_ID_FS2070X:
   break;
   case PCI_DEVICE_ID_NT200A01:
   case PCI_DEVICE_ID_NT80E3:
@@ -3401,6 +3403,9 @@ static const struct rte_pci_id ntacc_pci_id_map[] = {
   },
   {
     RTE_PCI_DEVICE(PCI_VENDOR_ID_NAPATECH,PCI_DEVICE_ID_NT400D13)
+  },
+  {
+    RTE_PCI_DEVICE(PCI_VENDOR_ID_NAPATECH,PCI_DEVICE_ID_FS2070X)
   },
   {
     .vendor_id = 0

--- a/src/dpdk/drivers/net/ntacc/rte_eth_ntacc.c
+++ b/src/dpdk/drivers/net/ntacc/rte_eth_ntacc.c
@@ -98,8 +98,8 @@ struct supportedDriver_s supportedDriver = {3, 11, 0};
 #define PCI_DEVICE_ID_NT400D11 0x0215
 #define PCI_DEVICE_ID_NT40A11  0x0225
 #define PCI_DEVICE_ID_NT400D13 0x0295
-#define PCI_DEVICE_ID_FS2070X  0x0255
-
+#define PCI_DEVICE_ID_F2070    0x0255
+#define PCI_DEVICE_ID_F3070    0x0415
 
 
 #define PCI_VENDOR_ID_INTEL          0x8086
@@ -3293,8 +3293,9 @@ static int rte_pmd_ntacc_dev_probe(struct rte_pci_driver *drv __rte_unused, stru
   case PCI_DEVICE_ID_NT400D11:
   case PCI_DEVICE_ID_NT40A11:
   case PCI_DEVICE_ID_NT400D13:
-  case PCI_DEVICE_ID_FS2070X:
-  break;
+  case PCI_DEVICE_ID_F2070:
+  case PCI_DEVICE_ID_F3070:
+    break;
   case PCI_DEVICE_ID_NT200A01:
   case PCI_DEVICE_ID_NT80E3:
   case PCI_DEVICE_ID_NT100E3:
@@ -3405,7 +3406,10 @@ static const struct rte_pci_id ntacc_pci_id_map[] = {
     RTE_PCI_DEVICE(PCI_VENDOR_ID_NAPATECH,PCI_DEVICE_ID_NT400D13)
   },
   {
-    RTE_PCI_DEVICE(PCI_VENDOR_ID_NAPATECH,PCI_DEVICE_ID_FS2070X)
+    RTE_PCI_DEVICE(PCI_VENDOR_ID_NAPATECH,PCI_DEVICE_ID_F2070)
+  },
+  {
+    RTE_PCI_DEVICE(PCI_VENDOR_ID_NAPATECH,PCI_DEVICE_ID_F3070)
   },
   {
     .vendor_id = 0

--- a/src/dpdk/lib/ethdev/ethdev_driver.h
+++ b/src/dpdk/lib/ethdev/ethdev_driver.h
@@ -2286,6 +2286,8 @@ struct rte_eth_fdir_conf {
 	struct rte_eth_fdir_flex_conf flex_conf;
 };
 
+#endif
+
 /**
  * @internal
  * Fetch from the driver what kind of configuration must be restored by ethdev layer,
@@ -2306,8 +2308,6 @@ __rte_internal
 uint64_t
 rte_eth_get_restore_flags(struct rte_eth_dev *dev,
 			  enum rte_eth_dev_operation op);
-
-#endif
 
 #ifdef __cplusplus
 }

--- a/src/sim/trex_sim_stateless.cpp
+++ b/src/sim/trex_sim_stateless.cpp
@@ -111,7 +111,7 @@ public:
         return true;
     }
 
-    void Delete() {
+    void Delete(int timeout_sec = 0) {
 
     }
 


### PR DESCRIPTION
- Fix compilation with GCC 14 on Rocky Linux 10 and --with-ntacc
- Fix linux (simulator) build with GCC 14 on Rocky Linux 10
- Fix SIGSEGV in CLatencyManager::start with GCC 14 AVX misalignment
- Add Napatech FS2070X PCI device support to ntacc driver
- Support for F2070 and F3070 added
